### PR TITLE
Demos: add meeting type/location and virtual meeting link

### DIFF
--- a/app/controllers/app/demos_controller.rb
+++ b/app/controllers/app/demos_controller.rb
@@ -91,7 +91,7 @@ module App
     end
 
     def demo_params
-      params.require(:demo).permit(:status, :outcome, :notes, :demo_link)
+      params.require(:demo).permit(:status, :outcome, :notes, :demo_link, :meeting_type, :meeting_location, :virtual_meeting_link)
     end
 
     def write_demo_update_activity!

--- a/app/controllers/app/lead_actions_controller.rb
+++ b/app/controllers/app/lead_actions_controller.rb
@@ -378,6 +378,10 @@ module App
           scheduled_at: scheduled_at,
           duration_minutes: book_demo_params[:duration_minutes].presence || 30,
           notes: book_demo_params[:notes].to_s.strip.presence,
+          demo_link: book_demo_params[:demo_link].to_s.strip.presence,
+          meeting_type: book_demo_params[:meeting_type].presence || :virtual,
+          meeting_location: book_demo_params[:meeting_location].to_s.strip.presence,
+          virtual_meeting_link: book_demo_params[:virtual_meeting_link].to_s.strip.presence,
           assigned_to_user: assigned_user,
           created_by_user: Current.user
         )
@@ -458,7 +462,7 @@ module App
     end
 
     def book_demo_params
-      params.permit(:scheduled_at, :duration_minutes, :notes, :assigned_to_user_id, :return_to)
+      params.permit(:scheduled_at, :duration_minutes, :notes, :demo_link, :meeting_type, :meeting_location, :virtual_meeting_link, :assigned_to_user_id, :return_to)
     end
 
     def post_demo_params

--- a/app/models/demo.rb
+++ b/app/models/demo.rb
@@ -37,6 +37,11 @@ class Demo < ApplicationRecord
     lost: "lost"
   }.freeze
 
+  MEETING_TYPES = {
+    virtual: "virtual",
+    in_person: "in_person"
+  }.freeze
+
   belongs_to :lead, optional: true, inverse_of: :demos
   belongs_to :account, optional: true, inverse_of: :demos
   belongs_to :created_by_user, class_name: "User", inverse_of: :created_demos
@@ -46,6 +51,7 @@ class Demo < ApplicationRecord
 
   enum :status, STATUSES, default: :scheduled, validate: true, prefix: true
   enum :outcome, OUTCOMES, validate: { allow_nil: true }, prefix: true
+  enum :meeting_type, MEETING_TYPES, default: :virtual, validate: true, prefix: true
 
   validates :scheduled_at, :duration_minutes, presence: true
   validates :duration_minutes, numericality: { only_integer: true, greater_than: 0 }

--- a/app/views/app/demos/show.html.erb
+++ b/app/views/app/demos/show.html.erb
@@ -41,6 +41,15 @@
         <dt class="col-sm-3 text-muted">Created by</dt>
         <dd class="col-sm-9"><%= @demo.created_by_user.full_name.presence || @demo.created_by_user.email_address %></dd>
 
+        <dt class="col-sm-3 text-muted">Virtual meeting link</dt>
+        <dd class="col-sm-9">
+          <% if @demo.virtual_meeting_link.present? %>
+            <%= link_to @demo.virtual_meeting_link, @demo.virtual_meeting_link, target: "_blank", rel: "noopener" %>
+          <% else %>
+            -
+          <% end %>
+        </dd>
+
         <dt class="col-sm-3 text-muted">Demo link</dt>
         <dd class="col-sm-9">
           <% if @demo.demo_link.present? %>
@@ -49,6 +58,15 @@
             -
           <% end %>
         </dd>
+
+        <dt class="col-sm-3 text-muted">Meeting</dt>
+        <dd class="col-sm-9"><%= @demo.meeting_type&.humanize || "Virtual" %></dd>
+
+        <dt class="col-sm-3 text-muted">Location</dt>
+        <dd class="col-sm-9"><%= @demo.meeting_location.presence || "-" %></dd>
+
+        <dt class="col-sm-3 text-muted">Prep Notes</dt>
+        <dd class="col-sm-9"><%= @demo.notes.presence || "-" %></dd>
       </dl>
 
       <% if policy(@demo).update? %>
@@ -70,8 +88,23 @@
                               class: "form-select" %>
             </div>
             <div class="col-md-4">
-              <%= form.label :demo_link, class: "form-label" %>
-              <%= form.url_field :demo_link, class: "form-control", placeholder: "https://meet.example.com/..." %>
+              <%= form.label :virtual_meeting_link, class: "form-label" %>
+              <%= form.url_field :virtual_meeting_link, class: "form-control", placeholder: "https://meet.example.com/..." %>
+            </div>
+            <div class="col-md-4">
+              <%= form.label :demo_link, "Demo link (website)", class: "form-label" %>
+              <%= form.url_field :demo_link, class: "form-control", placeholder: "https://example.com/demo-page" %>
+            </div>
+            <div class="col-md-4">
+              <%= form.label :meeting_type, class: "form-label" %>
+              <%= form.select :meeting_type,
+                              options_for_select(Demo.meeting_types.keys.map { |value| [value.humanize, value] }, @demo.meeting_type),
+                              {},
+                              class: "form-select" %>
+            </div>
+            <div class="col-md-4">
+              <%= form.label :meeting_location, class: "form-label" %>
+              <%= form.text_field :meeting_location, class: "form-control", placeholder: "Office address or venue" %>
             </div>
             <div class="col-12">
               <%= form.label :notes, "Outcome Notes", class: "form-label" %>
@@ -85,6 +118,13 @@
           <% end %>
         </div>
       <% end %>
+    </div>
+  </div>
+
+  <div class="card shadow-sm mb-3">
+    <div class="card-body">
+      <h2 class="h5 mb-2">Prep Notes</h2>
+      <p class="mb-0"><%= @demo.notes.presence || "-" %></p>
     </div>
   </div>
 

--- a/app/views/app/leads/show.html.erb
+++ b/app/views/app/leads/show.html.erb
@@ -255,6 +255,18 @@
           <%= form.datetime_local_field :scheduled_at, class: "form-control", required: true %>
           <%= form.label :duration_minutes, "Duration (minutes)", class: "form-label small text-muted mb-1 mt-1" %>
           <%= form.number_field :duration_minutes, class: "form-control", min: 1, step: 1, value: 30, required: true %>
+          <%= form.label :meeting_type, "Meeting type", class: "form-label small text-muted mb-1 mt-1" %>
+          <%= form.select :meeting_type,
+                          options_for_select([["Virtual", "virtual"], ["In person", "in_person"]], "virtual"),
+                          {},
+                          class: "form-select" %>
+          <%= form.label :demo_link, "Demo link (website)", class: "form-label small text-muted mb-1 mt-1" %>
+          <%= form.url_field :demo_link, class: "form-control", placeholder: "https://example.com/demo-page" %>
+          <div class="small text-muted">For virtual demos, fill Virtual meeting link. For in-person demos, capture a location.</div>
+          <%= form.label :virtual_meeting_link, "Virtual meeting link", class: "form-label small text-muted mb-1 mt-1" %>
+          <%= form.url_field :virtual_meeting_link, class: "form-control", placeholder: "https://meet.example.com/..." %>
+          <%= form.label :meeting_location, "Meeting location", class: "form-label small text-muted mb-1 mt-1" %>
+          <%= form.text_field :meeting_location, class: "form-control", placeholder: "Office address or venue" %>
           <% if manager_like %>
             <%= form.label :assigned_to_user_id, "Assign to", class: "form-label small text-muted mb-1 mt-1" %>
             <%= form.select :assigned_to_user_id,

--- a/db/migrate/20260306030000_add_meeting_fields_to_demos.rb
+++ b/db/migrate/20260306030000_add_meeting_fields_to_demos.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddMeetingFieldsToDemos < ActiveRecord::Migration[8.2]
+  def change
+    add_column :demos, :meeting_type, :string, null: false, default: "virtual"
+    add_column :demos, :meeting_location, :string
+
+    add_index :demos, :meeting_type
+  end
+end

--- a/db/migrate/20260306032000_add_virtual_meeting_link_to_demos.rb
+++ b/db/migrate/20260306032000_add_virtual_meeting_link_to_demos.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVirtualMeetingLinkToDemos < ActiveRecord::Migration[8.2]
+  def change
+    add_column :demos, :virtual_meeting_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_03_06_022000) do
+ActiveRecord::Schema[8.2].define(version: 2026_03_06_032000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -71,16 +71,20 @@ ActiveRecord::Schema[8.2].define(version: 2026_03_06_022000) do
     t.string "demo_link"
     t.integer "duration_minutes", default: 30, null: false
     t.bigint "lead_id"
+    t.string "meeting_location"
+    t.string "meeting_type", default: "virtual", null: false
     t.text "notes"
     t.string "outcome"
     t.datetime "scheduled_at", null: false
     t.string "status", default: "scheduled", null: false
     t.datetime "updated_at", null: false
+    t.string "virtual_meeting_link"
     t.index ["account_id"], name: "index_demos_on_account_id"
     t.index ["assigned_to_user_id", "scheduled_at"], name: "index_demos_on_assigned_to_user_id_and_scheduled_at"
     t.index ["assigned_to_user_id"], name: "index_demos_on_assigned_to_user_id"
     t.index ["created_by_user_id"], name: "index_demos_on_created_by_user_id"
     t.index ["lead_id"], name: "index_demos_on_lead_id"
+    t.index ["meeting_type"], name: "index_demos_on_meeting_type"
     t.index ["outcome"], name: "index_demos_on_outcome"
     t.index ["scheduled_at"], name: "index_demos_on_scheduled_at"
     t.index ["status"], name: "index_demos_on_status"

--- a/spec/models/demo_spec.rb
+++ b/spec/models/demo_spec.rb
@@ -29,4 +29,12 @@ RSpec.describe Demo, type: :model do
 
     expect(described_class.attended_or_no_show).to contain_exactly(completed, no_show)
   end
+
+  it "defaults meeting_type to virtual" do
+    creator = build_user(:sales_rep)
+    demo = described_class.create!(scheduled_at: 1.day.from_now, duration_minutes: 30, created_by_user: creator)
+
+    expect(demo.meeting_type).to eq("virtual")
+    expect(demo.meeting_type_virtual?).to be(true)
+  end
 end

--- a/spec/requests/app/lead_actions_spec.rb
+++ b/spec/requests/app/lead_actions_spec.rb
@@ -124,6 +124,9 @@ RSpec.describe "App::LeadActions", type: :request do
       post book_demo_app_lead_path(lead), params: {
         scheduled_at: 1.day.from_now.strftime("%Y-%m-%dT%H:%M"),
         duration_minutes: 45,
+        meeting_type: "in_person",
+        meeting_location: "Nairobi CBD Office",
+        virtual_meeting_link: "https://meet.example.com/intro",
         notes: "Product walkthrough",
         return_to: app_work_queue_path
       }
@@ -135,6 +138,9 @@ RSpec.describe "App::LeadActions", type: :request do
     expect(demo.lead).to eq(lead)
     expect(demo.assigned_to_user).to eq(rep)
     expect(demo.created_by_user).to eq(rep)
+    expect(demo.meeting_type).to eq("in_person")
+    expect(demo.meeting_location).to eq("Nairobi CBD Office")
+    expect(demo.virtual_meeting_link).to eq("https://meet.example.com/intro")
     expect(lead.reload.status).to eq("demo_booked")
   end
 
@@ -368,7 +374,7 @@ RSpec.describe "App::LeadActions", type: :request do
     rep = build_user(:sales_rep)
     lead = create_lead(name: "Already Converted Won", status: :invoice_sent, owner_user: rep)
     account = Account.create!(name: "Existing Account", converted_from_lead: lead)
-    Contact.create!(account: account, name: "Primary Contact")
+    Contact.create!(account: account, name: "Primary Contact", phone: "+15550001111")
     sign_in_as(rep)
 
     expect do


### PR DESCRIPTION
## Summary
- add demo meeting fields: `meeting_type` (`virtual`/`in_person`) and `meeting_location`
- add dedicated `virtual_meeting_link` so meeting URLs are captured separately from `demo_link` (demo website)
- keep `demo_link` visible/editable while directing virtual meeting instructions to `virtual_meeting_link`
- update lead booking flow to persist `meeting_type`, `meeting_location`, `virtual_meeting_link`, and `demo_link`
- update demo show/update UI to display and edit meeting type, location, virtual meeting link, and demo link
- display prep notes in demo summary and dedicated body section
- add model/request coverage for meeting defaults and booking persistence

## Validation
- `PATH="$HOME/.rbenv/shims:$PATH" bin/rails db:migrate`
- `PATH="$HOME/.rbenv/shims:$PATH" bin/rails test`
- `PATH="$HOME/.rbenv/shims:$PATH" bundle exec rspec spec/models/demo_spec.rb spec/requests/app/lead_actions_spec.rb`
