### PR TITLE
Demos index: desktop card grid + direct Open Demo

### DIFF
--- a/app/controllers/app/demos_controller.rb
+++ b/app/controllers/app/demos_controller.rb
@@ -15,7 +15,7 @@ module App
       now = Time.current
       @tab = params[:tab].presence_in(%w[today upcoming past]) || "today"
 
-      base_scope = policy_scope(Demo).includes(:lead, :assigned_to_user, :created_by_user)
+      base_scope = policy_scope(Demo).includes(:lead, :assigned_to_user)
       base_scope = base_scope.where(assigned_to_user_id: params[:assigned_to_user_id]) if manager_like? && params[:assigned_to_user_id].present?
       base_scope = base_scope.where(assigned_to_user_id: Current.user.id) unless manager_like?
 

--- a/app/views/app/demos/index.html.erb
+++ b/app/views/app/demos/index.html.erb
@@ -7,46 +7,65 @@
 </div>
 
 <% if @demos.any? %>
-  <div class="d-grid gap-3">
+  <div class="row g-3">
     <% @demos.each do |demo| %>
-      <div class="card">
-        <div class="card-body">
-          <div class="d-flex justify-content-between align-items-start gap-2 mb-2">
-            <div>
-              <h2 class="h5 mb-1"><%= demo.lead&.business_name.presence || "Unlinked demo" %></h2>
-              <div class="text-muted small"><%= l(demo.scheduled_at, format: :short) %> · <%= demo.duration_minutes %> min</div>
+      <div class="col-12 col-lg-6 col-xl-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body d-flex flex-column">
+            <div class="d-flex justify-content-between align-items-start gap-2 mb-2">
+              <div>
+                <h2 class="h5 mb-1"><%= demo.lead&.business_name.presence || "Unlinked demo" %></h2>
+                <div class="text-muted small"><%= l(demo.scheduled_at, format: :short) %> · <%= demo.duration_minutes %> min</div>
+              </div>
+              <span class="badge bg-success-subtle text-dark border"><%= demo.status.humanize %></span>
             </div>
-            <span class="badge bg-success-subtle text-dark"><%= demo.status.humanize %></span>
-          </div>
 
-          <div class="small mb-2">
-            <strong>Assigned:</strong>
-            <%= demo.assigned_to_user&.full_name.presence || demo.assigned_to_user&.email_address || "-" %>
-          </div>
-          <div class="small mb-3">
-            <strong>Outcome:</strong> <%= demo.outcome&.humanize || "-" %>
-          </div>
+            <div class="small text-muted mb-1">
+              Assigned: <%= demo.assigned_to_user&.full_name.presence || demo.assigned_to_user&.email_address || "-" %>
+            </div>
 
-          <div class="d-grid gap-2">
-            <%= link_to "Open Lead", demo.lead.present? ? app_lead_path(demo.lead) : app_demo_path(demo), class: "btn btn-outline-secondary" %>
-          </div>
+            <div class="small text-muted mb-1">
+              Meeting: <%= demo.meeting_type&.humanize || "Virtual" %>
+            </div>
 
-          <% if demo.lead.present? && (demo.status_scheduled? || demo.status_rescheduled?) %>
-            <hr>
-            <%= form_with url: complete_app_demo_path(demo), method: :post, local: true, class: "d-grid gap-2" do |form| %>
-              <%= form.select :status,
-                              options_for_select([["Completed", "completed"], ["No show", "no_show"]]),
-                              {},
-                              class: "form-select",
-                              required: true %>
-              <%= form.select :outcome,
-                              options_for_select(Demo::OUTCOMES.keys.map { |value| [value.to_s.humanize, value] }),
-                              { include_blank: "No outcome" },
-                              class: "form-select" %>
-              <%= form.text_field :notes, class: "form-control", placeholder: "Optional demo notes" %>
-              <%= form.submit "Complete Demo", class: "btn btn-primary" %>
+            <% if demo.meeting_type_virtual? && demo.virtual_meeting_link.present? %>
+              <div class="small mb-1">
+                Link: <%= link_to demo.virtual_meeting_link, demo.virtual_meeting_link, target: "_blank", rel: "noopener", class: "text-break" %>
+              </div>
+            <% elsif demo.meeting_location.present? %>
+              <div class="small mb-1">Location: <%= demo.meeting_location %></div>
             <% end %>
-          <% end %>
+
+            <% if demo.outcome.present? %>
+              <div class="small mb-2">Outcome: <span class="badge bg-light text-dark border"><%= demo.outcome.humanize %></span></div>
+            <% end %>
+
+            <div class="d-grid d-sm-flex gap-2 mt-auto">
+              <%= link_to "Open Demo", app_demo_path(demo), class: "btn btn-outline-primary flex-fill" %>
+              <% if demo.lead.present? %>
+                <%= link_to "Open Lead", app_lead_path(demo.lead), class: "btn btn-outline-secondary flex-fill" %>
+              <% else %>
+                <button class="btn btn-outline-secondary flex-fill" type="button" disabled>Open Lead</button>
+              <% end %>
+            </div>
+
+            <% if demo.lead.present? && (demo.status_scheduled? || demo.status_rescheduled?) %>
+              <hr>
+              <%= form_with url: complete_app_demo_path(demo), method: :post, local: true, class: "d-grid gap-2" do |form| %>
+                <%= form.select :status,
+                                options_for_select([["Completed", "completed"], ["No show", "no_show"]]),
+                                {},
+                                class: "form-select",
+                                required: true %>
+                <%= form.select :outcome,
+                                options_for_select(Demo::OUTCOMES.keys.map { |value| [value.to_s.humanize, value] }),
+                                { include_blank: "No outcome" },
+                                class: "form-select" %>
+                <%= form.text_field :notes, class: "form-control", placeholder: "Optional demo notes" %>
+                <%= form.submit "Complete Demo", class: "btn btn-primary" %>
+              <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## Summary
- keep existing Today/Upcoming/Past tab logic while ensuring eager loading with `includes(:lead, :assigned_to_user)`
- redesign `/app/demos` list into a responsive card grid: mobile single-column, `lg` two-column, `xl` three-column
- each card now shows lead name, schedule + duration, status badge, assignee, meeting details, and outcome (when present)
- add two clear actions per card: `Open Demo` (`app_demo_path`) and `Open Lead` (`app_lead_path` when lead exists)
- retain quick complete-demo controls for scheduled/rescheduled demos

## Validation
- `PATH="$HOME/.rbenv/shims:$PATH" bundle exec rspec spec/requests/app/demos_spec.rb`
